### PR TITLE
Add Talk PDF

### DIFF
--- a/pycon/package-lock.json
+++ b/pycon/package-lock.json
@@ -10,6 +10,9 @@
         "@slidev/theme-default": "latest",
         "@slidev/theme-seriph": "latest",
         "vue": "^3.4.21"
+      },
+      "devDependencies": {
+        "playwright-chromium": "^1.44.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -6661,6 +6664,34 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.4.0.tgz",
       "integrity": "sha512-sxMwpDw/ySY1WB2CE3+IdMuEcWibJ72DDOsXLkSmEaSzwEUaYBT6DWgOfBiHGCux4q433X6+OEFWjlVqp7gL6g=="
+    },
+    "node_modules/playwright-chromium": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright-chromium/-/playwright-chromium-1.44.0.tgz",
+      "integrity": "sha512-eae4op9jfzyybPfBOcS2o/EtrIT00OCBTLIA9EJz7sOfHwtUFY+H1XRTRdFD/j93tSS80uY8gyts+lX0zHYiHg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.44.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
+      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+      "devOptional": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/points-on-curve": {
       "version": "0.2.0",

--- a/pycon/package.json
+++ b/pycon/package.json
@@ -12,5 +12,8 @@
     "@slidev/theme-default": "latest",
     "@slidev/theme-seriph": "latest",
     "vue": "^3.4.21"
+  },
+  "devDependencies": {
+    "playwright-chromium": "^1.44.0"
   }
 }


### PR DESCRIPTION
This pull request primarily involves the addition of `playwright-chromium` as a development dependency in the `pycon` project. The changes are made to the `package.json` and `package-lock.json` files. 

* [`pycon/package.json`](diffhunk://#diff-3a2017d4e29c022ad0a87e81640d80286ce96b8ac535bec26ba3a8286b8bd26dR15-R17): Added `playwright-chromium` as a development dependency. This package is a browser automation library and will be used for automated testing or web scraping in the development environment.([pycon/package.jsonR15-R17](diffhunk://#diff-3a2017d4e29c022ad0a87e81640d80286ce96b8ac535bec26ba3a8286b8bd26dR15-R17))
* [`pycon/package-lock.json`](diffhunk://#diff-d64b96c52474d0216180c6d4c34085eef54d1e5ca4b2e4a30934f140e75cd033R13-R15): Two changes were made in this file. Firstly, `playwright-chromium` was added to the `devDependencies` object, indicating that it's a development-only dependency. Secondly, details about `playwright-chromium` and its own dependency `playwright-core` were added, providing information about their versions, source, and compatibility with Node.js versions. [[1]](diffhunk://#diff-d64b96c52474d0216180c6d4c34085eef54d1e5ca4b2e4a30934f140e75cd033R13-R15) [[2]](diffhunk://#diff-d64b96c52474d0216180c6d4c34085eef54d1e5ca4b2e4a30934f140e75cd033R6668-R6695)